### PR TITLE
Support for arbitrary path segment values

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,3 +66,21 @@ import { Link } from 'react-easy-router';
 
 <Link to="UserView" params={{user_id: 1}} className="user-link" {...props}>Text</Link>
 ```
+
+Specify [url-pattern](https://github.com/snd/url-pattern) options for URL
+matching:
+
+```js
+
+
+// Module route file: modules/user/routes.js
+
+import * as Handlers from './handlers';
+import { AppBase } from 'app';
+
+export default {
+    // Recognizes /user/ada.lovelace
+    UserView: {path: '/user/:name', options: {segmentValueCharset: '.a-z'},
+        component: Handlers.View, wrapper: AppBase},
+}
+```

--- a/src/Link.test.js
+++ b/src/Link.test.js
@@ -22,15 +22,25 @@ const routes = {
     page: {
         path: '/:foo',
         component: props => <div>Hello world</div>
-    }
+    },
+    pageWithOptions: {
+        path: '/:bar',
+        component: props => <div>Hello world</div>,
+        options: {segmentNameCharset: ',a-z'},
+    },
 };
 
 describe('<Link />', () => {
     const router = shallow(<Router history={history} routes={routes}/>);
 
-    it('render valid <Link /> component', () => {
+    it('renders valid <Link /> component', () => {
         const wrapper = shallow(<Link router={router} to="homepage"/>);
         expect(wrapper.prop('href')).to.equal('/');
+    });
+
+    it('renders <Link /> component with options', () => {
+        const wrapper = shallow(<Link router={router} to="pageWithOptions" params={{bar: "hello,world" }}/>);
+        expect(wrapper.prop('href')).to.equal('/hello,world');
     });
 
     it('renders children when passed in', () => {

--- a/src/Link.test.js
+++ b/src/Link.test.js
@@ -26,7 +26,7 @@ const routes = {
     pageWithOptions: {
         path: '/:bar',
         component: props => <div>Hello world</div>,
-        options: {segmentNameCharset: ',a-z'},
+        options: {segmentValueCharset: ',a-z'},
     },
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,7 +25,7 @@ export function findMatch(path, routes) {
     const query = Qs.parse(rawQuery);
 
     for (let name in routes) {
-        const route = createRoute(routes[name].path);
+        const route = createRoute(routes[name].path, routes[name].options);
 
         const params = route.match(rawPath);
         if (null === params) {
@@ -73,5 +73,6 @@ export function reverse(to, params = {}, query = {}) {
 
     let queryString = Object.keys(query).length ? '?' + Qs.stringify(query) : '';
 
-    return createRoute(store.get(to).path).stringify(params) + queryString;
+    const route = store.get(to)
+    return createRoute(route.path, route.options).stringify(params) + queryString;
 }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -29,6 +29,13 @@ describe('utils', () => {
         expect(route.match(url.split('?')[0])).to.be.deep.equal({});
     });
 
+    it('matches with segment value option', () => {
+        let route = createRoute('/segment-name/:bar', {segmentValueCharset: ',a-z'}),
+            url = '/segment-name/hello,world';
+
+        expect(route.match(url)).to.be.deep.equal({bar: 'hello,world'});
+    });
+
     it('find match from routes', () => {
         store.set({
             user_list: { path: '/user' }


### PR DESCRIPTION
First, thanks for this library. It works great as a lightweight router.

I wanted to have commas in the path segments (they are locations like Leeds, AL). There is partial support for this internally in the library but it is not exposed to the user. I made a couple of changes to expose it, added tests & docs.